### PR TITLE
Use UNI testnet with Keplr

### DIFF
--- a/src/context/chain.js
+++ b/src/context/chain.js
@@ -1,7 +1,7 @@
 export const chain = {
     "name": "Juno Uni",
     "chain_id": "uni",
-    "lcd": " https://api.uni.junomint.com:443/",
+    "lcd": "https://api.uni.junomint.com:443/",
     "rpc": "https://rpc.uni.junomint.com:443/",
     "coinDenom": "JUNOX",
     "coinMinimalDenom": "ujunox",


### PR DESCRIPTION
Closes #4 

This will do the proper Keplr thing, but looking at the network, it gets an error when querying.

I copied the data there and tried to reproduce:

`curl -v -X POST -d '{"jsonrpc": "2.0", "id": 385457786638, "method": "status", "params": {}}' http://uni.junochain.com:26657/`

But that gives me proper status info. Maybe CORS?

To reproduce: `npm run start` and connect with keeper