### PR TITLE
Update to uni-2

### DIFF
--- a/src/context/chain.js
+++ b/src/context/chain.js
@@ -3,7 +3,7 @@
  */
 export const chain = {
   name: "Juno Uni",
-  chain_id: "uni",
+  chain_id: "uni-2",
   lcd: "https://api.uni.wyndex.io:443/",
   rpc: "https://rpc.uni.wyndex.io:443/",
   coinDenom: "JUNOX",

--- a/src/scripts/config.js
+++ b/src/scripts/config.js
@@ -21,12 +21,12 @@ const config = {
 };
 
 const contracts = {
-    wyndId: 214,
-    facuetId: 215,
-    investId: 216,
-    wyndAddr: "juno13fyvtf5fnatl50qqr2fnk2st6s90avtasq5erk8yj6drj6ykzn0qcjm7ej",
-    faucetAddr: "juno1me0zwlldnr40373mpd6d3vf8edxx9gndedjw0l4x05lcg4h2ml8sjgyk6l",
-    investAddr: "juno1qykpkn9j755y4pzhvw5slu7cn9ung42hk3vj55r0gfdj5u8up5pqgca7u2",
+    wyndId: 37,
+    facuetId: 38,
+    investId: 39,
+    wyndAddr: "juno10vdgcaujh4r2ylvvauvuufgu9xggl6dh9z6qfcq640854my77fpskmu4mn",
+    faucetAddr: "juno1kmya9p26a9ecq07sxdgkkfmr8pcqyszv7gmkyqz6hlt006qr75lq2a8mw9",
+    investAddr: "juno1z2cp6qnufdjvc8n24p59dumwpngkgxal4usz2w2futsqrglgsskqcnjh4p",
 }
 
 const accounts = {

--- a/src/scripts/query_wynd.js
+++ b/src/scripts/query_wynd.js
@@ -4,6 +4,8 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 const { CosmWasmClient } = require('@cosmjs/cosmwasm-stargate');
 
+const { contracts } = require("./config");
+
 // from ../context/chain.js
 const config = {
     endpoint: 'https://rpc.uni.wyndex.io:443/',
@@ -13,25 +15,23 @@ const config = {
       'wild enact trust mean try snack evoke bring gown core curtain ahead',
 };
   
-const wyndAddress = "juno1wjur4gvzn0ccnffyuhvs3qxgsxn6ga86wpd2y8s2ufck4c2zmrfsyn44rq";
-
 async function main() {
     const client = await CosmWasmClient.connect(config.endpoint);
 
     const toCheck = [
         // main accounts
-        "juno1pxa9trxza5e2w7sdk2a0xng86y4fnena4e0pka",
-        "juno1qd3p79cd82hz8p20gr4gcqze33eauuka6929w0",
-        // secondary unloaded account
-        "juno19u5ugg4r3haggcstnk7vccxfyju3n56hf23r07",
+        "juno1v2gdcsw27ncrrch3e78c5tfym4su8zlwv2r9rd",
+        "juno14zw7q2rhk76uzvpj3a9yw88zjp0qgaa79zf9dv",
+        "juno1l3493que6nqetkf73qc2mfknd5jn5mlc7qw8wv",
         // faucet itself
-        "juno1w6tvhn4gsp5wxfzqr08rgvfe29zx06rq92nep5j8scvv5dfl79ws72t4uw"
+        "juno1kmya9p26a9ecq07sxdgkkfmr8pcqyszv7gmkyqz6hlt006qr75lq2a8mw9"
     ];
 
     for (const address of toCheck) {
+        const { amount} = await client.getBalance(address, "ujunox");
         const query = {balance: {address}};
-        const {balance} = await client.queryContractSmart(wyndAddress, query);
-        console.log(`${address}: ${balance}`);
+        const {balance} = await client.queryContractSmart(contracts.wyndAddr, query);
+        console.log(`${address}: ${amount} ujunox / ${balance} uWYND`);
     }
 
 }  


### PR DESCRIPTION
The Uni testnet has been wiped clean and restarted twice since our hackathon.

This PR updates the chain id (so we can sign transactions with Keplr) and new code ids and contract addresses after I redeployed the app.

We need more Junox to hand out to the faucet (and the oracle), so people can really use this. I am waiting on that.